### PR TITLE
Add SysWM support

### DIFF
--- a/shim.h
+++ b/shim.h
@@ -1,5 +1,7 @@
 #ifdef __APPLE__
 #include "/usr/local/include/SDL2/SDL.h"
+#include "/usr/local/include/SDL2/SDL_syswm.h"
 #else
 #include <SDL2/SDL.h>
+#include <SDL2/SDL_syswm.h>
 #endif


### PR DESCRIPTION
This pull request adds [SDL_SysWMinfo](https://wiki.libsdl.org/SDL_SysWMinfo) support to this package. SysWM is a "A structure that contains system-dependent information about a window" and is useful for example to implement a custom Metal renderer.